### PR TITLE
Implement LeColor so that the a pixel is RGBA on all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,14 +70,14 @@ target_link_libraries(
     ${LINK_LIBRARIES}
 )
 
-#if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-#    set_target_properties(le3d PROPERTIES LINK_FLAGS "-m32")
-#    target_compile_options(le3d PUBLIC -m32) 
-#    target_compile_options(le3d PRIVATE -march=pentium4 -Wall -ffast-math -mfpmath=sse -fno-exceptions -fno-rtti -fno-stack-protector #-fno-math-errno -fno-ident -ffunction-sections)
-#    if (WIN32)
-#        target_compile_options(le3d PRIVATE -D__MSVCRT_VERSION__=0x0700)
-#    endif()
-#endif()
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set_target_properties(le3d PROPERTIES LINK_FLAGS "-m32")
+    target_compile_options(le3d PUBLIC -m32) 
+    target_compile_options(le3d PRIVATE -march=pentium4 -Wall -ffast-math -mfpmath=sse -fno-exceptions -fno-rtti -fno-stack-protector -fno-math-errno -fno-ident -ffunction-sections)
+    if (WIN32)
+        target_compile_options(le3d PRIVATE -D__MSVCRT_VERSION__=0x0700)
+    endif()
+endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(le3d PRIVATE -D__MSVCRT_VERSION__=0x0700 -D_CRT_SECURE_NO_WARNINGS=1 -D_USE_MATH_DEFINES=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,14 +70,14 @@ target_link_libraries(
     ${LINK_LIBRARIES}
 )
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set_target_properties(le3d PROPERTIES LINK_FLAGS "-m32")
-    target_compile_options(le3d PUBLIC -m32) 
-    target_compile_options(le3d PRIVATE -march=pentium4 -Wall -ffast-math -mfpmath=sse -fno-exceptions -fno-rtti -fno-stack-protector -fno-math-errno -fno-ident -ffunction-sections)
-    if (WIN32)
-        target_compile_options(le3d PRIVATE -D__MSVCRT_VERSION__=0x0700)
-    endif()
-endif()
+#if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+#    set_target_properties(le3d PROPERTIES LINK_FLAGS "-m32")
+#    target_compile_options(le3d PUBLIC -m32) 
+#    target_compile_options(le3d PRIVATE -march=pentium4 -Wall -ffast-math -mfpmath=sse -fno-exceptions -fno-rtti -fno-stack-protector #-fno-math-errno -fno-ident -ffunction-sections)
+#    if (WIN32)
+#        target_compile_options(le3d PRIVATE -D__MSVCRT_VERSION__=0x0700)
+#    endif()
+#endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(le3d PRIVATE -D__MSVCRT_VERSION__=0x0700 -D_CRT_SECURE_NO_WARNINGS=1 -D_USE_MATH_DEFINES=1)

--- a/engine/bitmap.cpp
+++ b/engine/bitmap.cpp
@@ -569,7 +569,7 @@ void LeBitmap::makeMipmaps()
 				int g = (s[1] + s[1+4] + s[1+mtx*2*4] + s[1+4+mtx*2*4]) >> 2;
 				int b = (s[2] + s[2+4] + s[2+mtx*2*4] + s[2+4+mtx*2*4]) >> 2;
 				int a = (s[3] + s[3+4] + s[3+mtx*2*4] + s[3+4+mtx*2*4]) >> 2;
-				* p++ = (a << 24) | (b << 16) | (g << 8) | r;
+				* p++ = LeColor(r, g, b, a);
 				o += 2;
 			}
 			o += mtx * 2;

--- a/engine/bitmap.cpp
+++ b/engine/bitmap.cpp
@@ -564,11 +564,14 @@ void LeBitmap::makeMipmaps()
 
 		for (int y = 0; y < mty; y++) {
 			for (int x = 0; x < mtx; x++) {
-				uint8_t * s = (uint8_t *) o;
-				int r = (s[0] + s[0+4] + s[0+mtx*2*4] + s[0+4+mtx*2*4]) >> 2;
-				int g = (s[1] + s[1+4] + s[1+mtx*2*4] + s[1+4+mtx*2*4]) >> 2;
-				int b = (s[2] + s[2+4] + s[2+mtx*2*4] + s[2+4+mtx*2*4]) >> 2;
-				int a = (s[3] + s[3+4] + s[3+mtx*2*4] + s[3+4+mtx*2*4]) >> 2;
+				LeColor * s1 = o;
+				LeColor * s2 = o+1;
+				LeColor * s3 = o + mtx*2*4;
+				LeColor * s4 = o + mtx*2*4+1;
+				int r = (s1->r + s2->r + s3->r + s4->r) >> 2;
+				int g = (s1->g + s2->g + s3->g + s4->g) >> 2;
+				int b = (s1->b + s2->b + s3->b + s4->b) >> 2;
+				int a = (s1->a + s2->a + s3->a + s4->a) >> 2;
 				* p++ = LeColor(r, g, b, a);
 				o += 2;
 			}

--- a/engine/bitmap.cpp
+++ b/engine/bitmap.cpp
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -70,12 +70,12 @@ LeBmpFont::~LeBmpFont()
 
 /*****************************************************************************/
 /**
-	\fn void LeBitmap::clear(uint32_t color)
+	\fn void LeBitmap::clear(LeColor color)
 	\brief Clear the image with the specified color
 	\param[in] color RGBA 32bit color
 */
 #if LE_USE_SIMD == 1 && LE_USE_SSE2 == 1
-void LeBitmap::clear(uint32_t color)
+void LeBitmap::clear(LeColor color)
 {
 	int size = tx * ty;
 	int b = size >> 2;
@@ -86,7 +86,7 @@ void LeBitmap::clear(uint32_t color)
 	for (int t = 0; t < b; t ++)
 		*p_4++ = color_4;
 
-	uint32_t * p = (uint32_t *) p_4;
+	LeColor * p = (LeColor *) p_4;
 	if (r == 0) return;
 	*p++ = color;
 	if (r == 1) return;
@@ -94,13 +94,12 @@ void LeBitmap::clear(uint32_t color)
 	if (r == 2) return;
 	*p++ = color;
 }
-
 #else
 
-void LeBitmap::clear(uint32_t color)
+void LeBitmap::clear(LeColor color)
 {
 	size_t size = tx * ty;
-	uint32_t * p = (uint32_t *) data;
+	LeColor * p = (LeColor *) data;
 	for (size_t t = 0; t < size; t ++)
 		p[t] = color;
 }
@@ -108,7 +107,7 @@ void LeBitmap::clear(uint32_t color)
 
 /*****************************************************************************/
 /**
-	\fn void LeBitmap::rect(int32_t x, int32_t y, int32_t w, int32_t h, uint32_t color)
+	\fn void LeBitmap::rect(int32_t x, int32_t y, int32_t w, int32_t h, LeColor color)
 	\brief Fill a rectangle with the specified color
 	\param[in] x horizontal position of the rectangle (pixels)
 	\param[in] y vertical position of the rectangle (pixels)
@@ -116,7 +115,7 @@ void LeBitmap::clear(uint32_t color)
 	\param[in] h height of the rectangle (pixels)
 	\param[in] color RGBA 32bit color
 */
-void LeBitmap::rect(int32_t x, int32_t y, int32_t w, int32_t h, uint32_t color)
+void LeBitmap::rect(int32_t x, int32_t y, int32_t w, int32_t h, LeColor color)
 {
 	if (x >= tx) return;
 	if (y >= ty) return;
@@ -130,7 +129,7 @@ void LeBitmap::rect(int32_t x, int32_t y, int32_t w, int32_t h, uint32_t color)
 	if (xe > tx) xe = tx;
 	if (ye > ty) ye = ty;
 
-	uint32_t * d = (uint32_t *) data;
+	LeColor * d = (LeColor *) data;
 	d += x + y * tx;
 	w = xe - x;
 	h = ye - y;
@@ -173,8 +172,8 @@ void LeBitmap::blit(int32_t xDst, int32_t yDst, const LeBitmap * src, int32_t xS
 	if (xeDst > tx) xeDst = tx;
 	if (yeDst > ty) yeDst = ty;
 
-	uint32_t * d = (uint32_t *) data;
-	uint32_t * s = (uint32_t *) src->data;
+	LeColor * d = (LeColor *) data;
+	LeColor * s = (LeColor *) src->data;
 	d += xDst + yDst * tx;
 	s += xSrc + ySrc * src->tx;
 	w = xeDst - xDst;
@@ -222,8 +221,8 @@ void LeBitmap::alphaBlit(int32_t xDst, int32_t yDst, const LeBitmap * src, int32
 	if (xeDst > tx) xeDst = tx;
 	if (yeDst > ty) yeDst = ty;
 
-	uint32_t * d = (uint32_t *) data;
-	uint32_t * s = (uint32_t *) src->data;
+	LeColor * d = (LeColor *) data;
+	LeColor * s = (LeColor *) src->data;
 	d += xDst + yDst * tx;
 	s += xSrc + ySrc * src->tx;
 	w = xeDst - xDst;
@@ -278,8 +277,8 @@ void LeBitmap::alphaBlit(int32_t xDst, int32_t yDst, const LeBitmap * src, int32
 	if (xeDst > tx) xeDst = tx;
 	if (yeDst > ty) yeDst = ty;
 
-	uint32_t * d = (uint32_t *) data;
-	uint32_t * s = (uint32_t *) src->data;
+	LeColor * d = (LeColor *) data;
+	LeColor * s = (LeColor *) src->data;
 	d += xDst + yDst * tx;
 	s += xSrc + ySrc * src->tx;
 	w = xeDst - xDst;
@@ -348,8 +347,8 @@ void LeBitmap::alphaScaleBlit(int32_t xDst, int32_t yDst, int32_t wDst, int32_t 
 	if (xeDst > tx) xeDst = tx;
 	if (yeDst > ty) yeDst = ty;
 
-	uint32_t * d = (uint32_t *) data;
-	uint32_t * s = (uint32_t *) src->data;
+	LeColor * d = (LeColor *) data;
+	LeColor * s = (LeColor *) src->data;
 	d += xDst + yDst * tx;
 
 	wDst = xeDst - xDst;
@@ -363,7 +362,7 @@ void LeBitmap::alphaScaleBlit(int32_t xDst, int32_t yDst, int32_t wDst, int32_t 
 	int32_t v = vb;
 	for (int y = 0; y < hDst; y++){
 		for (int x = 0; x < wDst; x++){
-			uint32_t * p = &s[(u >> 16) + (v >> 16) * src->tx];
+			LeColor * p = &s[(u >> 16) + (v >> 16) * src->tx];
 			u += us;
 
 			__m128i dp, sp;
@@ -417,8 +416,8 @@ void LeBitmap::alphaScaleBlit(int32_t xDst, int32_t yDst, int32_t wDst, int32_t 
 	if (xeDst > tx) xeDst = tx;
 	if (yeDst > ty) yeDst = ty;
 
-	uint32_t * d = (uint32_t *) data;
-	uint32_t * s = (uint32_t *) src->data;
+	LeColor * d = (LeColor *) data;
+	LeColor * s = (LeColor *) src->data;
 	d += xDst + yDst * tx;
 
 	wDst = xeDst - xDst;
@@ -488,7 +487,7 @@ void LeBitmap::text(int x, int y, const char * text, int length, const LeBmpFont
 */
 void LeBitmap::allocate(int tx, int ty)
 {
-	data = new uint32_t[tx*ty];
+	data = new LeColor[tx*ty];
 	dataAllocated = true;
 
 	this->tx = tx;
@@ -505,7 +504,7 @@ void LeBitmap::allocate(int tx, int ty)
 void LeBitmap::deallocate()
 {
 	if (dataAllocated && data)
-		delete[] (uint32_t *) data;
+		delete[] (LeColor *) data;
 	dataAllocated = false;
 
 	for (int l = 1; l < mmLevels; l++)
@@ -553,7 +552,7 @@ void LeBitmap::makeMipmaps()
 	int mtx = tx / 2;
 	int mty = ty / 2;
 
-	uint32_t * o = (uint32_t *) data;
+	LeColor * o = (LeColor *) data;
 
 	for (int l = 0; l < LE_BMP_MIPMAPS; l++) {
 		if (mtx < 4 || mty < 4) break;
@@ -561,7 +560,7 @@ void LeBitmap::makeMipmaps()
 		LeBitmap * bmp = new LeBitmap();
 		bmp->allocate(mtx, mty);
 
-		uint32_t * p = (uint32_t *) bmp->data;
+		LeColor * p = (LeColor *) bmp->data;
 
 		for (int y = 0; y < mty; y++) {
 			for (int x = 0; x < mtx; x++) {
@@ -578,7 +577,7 @@ void LeBitmap::makeMipmaps()
 
 		mtx /= 2;
 		mty /= 2;
-		o = (uint32_t *) bmp->data;
+		o = (LeColor *) bmp->data;
 
 		mipmaps[mmLevels++] = bmp;
 	}

--- a/engine/bitmap.h
+++ b/engine/bitmap.h
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 Frï¿½dï¿½ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/engine/bitmap.h
+++ b/engine/bitmap.h
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Fr�d�ric Meslin
+	Copyright (c) 2015-2018 Frédéric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/engine/bitmap.h
+++ b/engine/bitmap.h
@@ -34,6 +34,7 @@
 #define LE_BITMAP_H
 
 #include "global.h"
+#include "color.h"
 #include "config.h"
 
 /*****************************************************************************/
@@ -60,8 +61,8 @@ public:
 	LeBitmap();
 	~LeBitmap();
 
-	void clear(uint32_t color);
-	void rect(int32_t x, int32_t y, int32_t w, int32_t h, uint32_t color);
+	void clear(LeColor color);
+	void rect(int32_t x, int32_t y, int32_t w, int32_t h, LeColor color);
 	void blit(int32_t xDst, int32_t yDst, const LeBitmap * src, int32_t xSrc, int32_t ySrc, int32_t w, int32_t h);
 	void alphaBlit(int32_t xDst, int32_t yDst, const LeBitmap * src, int32_t xSrc, int32_t ySrc, int32_t w, int32_t h);
 	void alphaScaleBlit(int32_t xDst, int32_t yDst, int32_t wDst, int32_t hDst, const LeBitmap * src, int32_t xSrc, int32_t ySrc, int32_t wSrc, int32_t hSrc);

--- a/engine/bmpcache.cpp
+++ b/engine/bmpcache.cpp
@@ -56,7 +56,7 @@ LeBmpCache::LeBmpCache() :
 // Create the default bitmap (32x32 all white)
 	LeBitmap * defBitmap = new LeBitmap();
 	defBitmap->allocate(32, 32);
-	memset(defBitmap->data, 0xFF, 32 * 32 * sizeof(uint32_t));
+	memset(defBitmap->data, 0xFF, 32 * 32 * sizeof(LeColor));
 
 // Register the default bitmap
 	Slot * defSlot = &cacheSlots[0];

--- a/engine/bmpfile.cpp
+++ b/engine/bmpfile.cpp
@@ -210,7 +210,7 @@ int LeBmpFile::readBitmap(FILE * file, LeBitmap * bitmap)
 	srcScan = bitmap->tx * (info.biBitCount >> 3);
 	srcScan = (srcScan + 0x3) & ~0x3;
 
-	bitmap->data = new uint32_t[bitmap->tx * bitmap->ty];
+	bitmap->data = new LeColor[bitmap->tx * bitmap->ty];
 	bitmap->dataAllocated = true;
 
 // Load bitmap data
@@ -248,14 +248,13 @@ int LeBmpFile::readBitmap(FILE * file, LeBitmap * bitmap)
 	// Parse a 24 bits image
 		for (int y = 0; y < bitmap->ty; y ++) {
 			fread(buffer, srcScan, 1, file);
-			uint32_t * d = (uint32_t *) data;
+			LeColor * d = (LeColor *) data;
 			uint8_t	 * s = buffer;
 			for (int i = 0; i < bitmap->tx; i ++) {
-				uint32_t r, g, b;
-				b = * s++;
-				g = * s++;
-				r = * s++;
-				* d++ = (r << 16) | (g << 8) | b;
+				d->b = * s++;
+				d->g = * s++;
+				d->r = * s++;
+				d++;
 			}
 			if (upsidedown) data -= dstScan;
 			else data += dstScan;

--- a/engine/bset.cpp
+++ b/engine/bset.cpp
@@ -86,8 +86,8 @@ void LeBSet::shadowCopy(LeBSet * copy) const
 	copy->flags = flags;
 
 	if (shades) {
-		copy->shades = new uint32_t[noBillboards];
-		memcpy(copy->shades, shades, noBillboards * sizeof(uint32_t));
+		copy->shades = new LeColor[noBillboards];
+		memcpy(copy->shades, shades, noBillboards * sizeof(LeColor));
 	}
 }
 
@@ -147,7 +147,7 @@ void LeBSet::allocate(int noBillboards)
 
 	places = new LeVertex[noBillboards];
 	sizes = new float[noBillboards * 2];
-	colors = new uint32_t[noBillboards];
+	colors = new LeColor[noBillboards];
 	texSlots = new int[noBillboards];
 	flags = new int[noBillboards];
 

--- a/engine/bset.cpp
+++ b/engine/bset.cpp
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -119,7 +119,7 @@ void LeBSet::basic()
 	for (int b = 0; b < noBillboards; b++) {
 		sizes[b*2+0] = 1.0f;
 		sizes[b*2+1] = 1.0f;
-		colors[b] = 0x00FFFFFF;
+		colors[b] = LeColor::rgb(0xFFFFFF);
 		texSlots[b] = 0;
 		flags[b] = LE_BSET_EXIST;
 	}

--- a/engine/bset.h
+++ b/engine/bset.h
@@ -36,6 +36,7 @@
 #include "global.h"
 #include "config.h"
 
+#include "color.h"
 #include "geometry.h"
 
 /*****************************************************************************/
@@ -77,14 +78,14 @@ public:
 // Static billboards data
 	LeVertex * places;		/**< Position per billboard */ 
 	float * sizes;			/**< Size (x, y) per billboard */
-	uint32_t * colors;		/**< Color per billboard */
+	LeColor * colors;		/**< Color per billboard */
 	int * texSlots;			/**< Texture slot per billboard */
 	int * flags;			/**< Flag per billboard */
 	
 	int noBillboards;		/**< Number of allocated billboards */
 
 // Computed billboards data
-	uint32_t * shades;		/**< Shade color per billboard (lighting) */
+	LeColor * shades;		/**< Shade color per billboard (lighting) */
 	bool allocated;			/**< Has data been allocated */
 };
 

--- a/engine/color.h
+++ b/engine/color.h
@@ -37,8 +37,8 @@
 
 class LeColor {
 public:
-    LeColor(): r(0), g(0), b(0), a(0) {}
-	LeColor(uint8_t const& _r, uint8_t const& _g, uint8_t const& _b, uint8_t const& _a): r(_r), g(_g), b(_b), a(_a) {} 
+    LeColor(): b(0), g(0), r(0), a(0) {}
+	LeColor(uint8_t const& _r, uint8_t const& _g, uint8_t const& _b, uint8_t const& _a): b(_b), g(_g), r(_r), a(_a) {} 
 	LeColor& operator=(LeColor const& color) {
         r = color.r;
         g = color.g;
@@ -46,7 +46,7 @@ public:
         a = color.a;
         return *this;
     }
-	explicit LeColor(int const& color): r(color >> 16), g(color >> 8), b(color), a(color >> 24) {};
+	explicit LeColor(int const& color): b(color), g(color >> 8), r(color >> 16), a(color >> 24) {};
 	LeColor& operator=(int const& color) {
 		r = color >> 16;
 		g = color >> 8;

--- a/engine/color.h
+++ b/engine/color.h
@@ -1,0 +1,66 @@
+/**
+	\file color.h
+	\brief LightEngine 3D: Color implementation
+	\brief All platforms implementation
+	\author Andreas Streichardt <andreas@mop.koeln>
+	\twitter @m0ppers
+	\website https://mop.koeln
+	\copyright Andreas Streichardt 2018
+	\version 1.5
+
+	The MIT License (MIT)
+	Copyright (c) 2015-2018 Frédéric Meslin
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+*/
+
+#ifndef LE_COLOR_H
+#define LE_COLOR_H
+
+#include <stdint.h>
+
+struct LeColor {
+    LeColor(): r(0), g(0), b(0), a(0) {}
+    LeColor(uint32_t color) :
+		r(color >> 24),
+		g(color >> 16),
+		b(color >> 8),
+		a(color) {
+    }
+
+	LeColor& operator=(LeColor color) {
+        r = color.r;
+        g = color.g;
+        b = color.b;
+        a = color.a;
+        return *this;
+    }
+
+	operator int() {
+		return (r << 24) | (g << 16) | (b << 8) << a;
+	}
+
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+    uint8_t a;
+};
+
+
+#endif

--- a/engine/color.h
+++ b/engine/color.h
@@ -35,30 +35,43 @@
 
 #include <stdint.h>
 
-struct LeColor {
+class LeColor {
+public:
     LeColor(): r(0), g(0), b(0), a(0) {}
-    LeColor(uint32_t color) :
-		r(color >> 24),
-		g(color >> 16),
-		b(color >> 8),
-		a(color) {
-    }
-
-	LeColor& operator=(LeColor color) {
+	LeColor(uint8_t const& _r, uint8_t const& _g, uint8_t const& _b, uint8_t const& _a): r(_r), g(_g), b(_b), a(_a) {} 
+	LeColor& operator=(LeColor const& color) {
         r = color.r;
         g = color.g;
         b = color.b;
         a = color.a;
         return *this;
     }
+	explicit LeColor(int const& color): r(color >> 16), g(color >> 8), b(color), a(color >> 24) {};
+	LeColor& operator=(int const& color) {
+		r = color >> 16;
+		g = color >> 8;
+		b = color;
+		a = color >> 24;
 
-	operator int() {
-		return (r << 24) | (g << 16) | (b << 8) << a;
+		return *this;
+	}
+    operator int() {
+	    return (r << 16) | (g << 8) | b | (a << 24);
 	}
 
-    uint8_t r;
-    uint8_t g;
+public:
+    static LeColor rgba(uint32_t const& rgba) {
+		return LeColor(rgba >> 16, rgba >> 8, rgba, rgba >> 24);
+    }
+    
+	static LeColor rgb(uint32_t const& rgb) {
+		return LeColor(rgb >> 16, rgb >> 8, rgb, 1);
+    }
+
+public:
     uint8_t b;
+    uint8_t g;
+    uint8_t r;
     uint8_t a;
 };
 

--- a/engine/config.h
+++ b/engine/config.h
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -59,14 +59,14 @@
 	#define LE_RENDERER_3DFRUSTRUM		1						/** Use a 3D frustrum to clip triangles */
 	#define LE_RENDERER_2DFRAME			0						/** Use a 2D frame to clip triangles */
 
-	#define LE_RENDERER_INTRASTER		0						/** Enable fixed point or floating point rasterizing */
+	#define LE_RENDERER_INTRASTER		1						/** Enable fixed point or floating point rasterizing */
 	#define LE_RENDERER_MIPMAPS			1						/** Enable mipmapping on textures */
 
 	#define LE_TRILIST_MAX				50000					/** Maximum number of triangles in display list */
 	#define LE_VERLIST_MAX				(3 * LE_TRILIST_MAX)	/** Maximum number of vertexes in transformation buffer */
 
 /** Performance optimizations */
-	#define LE_USE_SIMD					1						/** Use SIMD instructions & vectors */
-	#define LE_USE_SSE2					1						/** Use Intel SSE2 instructions */
+	#define LE_USE_SIMD					0						/** Use SIMD instructions & vectors */
+	#define LE_USE_SSE2					0						/** Use Intel SSE2 instructions */
 
 #endif // LE_CONFIG_H

--- a/engine/config.h
+++ b/engine/config.h
@@ -66,7 +66,13 @@
 	#define LE_VERLIST_MAX				(3 * LE_TRILIST_MAX)	/** Maximum number of vertexes in transformation buffer */
 
 /** Performance optimizations */
-	#define LE_USE_SIMD					0						/** Use SIMD instructions & vectors */
-	#define LE_USE_SSE2					0						/** Use Intel SSE2 instructions */
+	#define LE_USE_SIMD					1						/** Use SIMD instructions & vectors */
+	#define LE_USE_SSE2					1						/** Use Intel SSE2 instructions */
+
+#ifdef AMIGA
+	#define LE_PIXFMT_ARGB
+#else
+	#define LE_PIXFMT_BGRA
+#endif
 
 #endif // LE_CONFIG_H

--- a/engine/config.h
+++ b/engine/config.h
@@ -69,10 +69,4 @@
 	#define LE_USE_SIMD					1						/** Use SIMD instructions & vectors */
 	#define LE_USE_SSE2					1						/** Use Intel SSE2 instructions */
 
-#ifdef AMIGA
-	#define LE_PIXFMT_ARGB
-#else
-	#define LE_PIXFMT_BGRA
-#endif
-
 #endif // LE_CONFIG_H

--- a/engine/draw_unix.cpp
+++ b/engine/draw_unix.cpp
@@ -42,12 +42,15 @@
 
 #include <stdio.h>
 
+static char* translated = 0;
+
 /*****************************************************************************/
 LeDraw::LeDraw(LeDrawingContext context, int width, int height) :
 	width(width), height(height),
 	frontContext(context),
 	bitmap(0)
 {
+	translated = (char*) malloc(width * height * 4 * sizeof(char));
 	Visual * visual = DefaultVisual((Display *) context.display, 0);
 	if (visual->c_class != TrueColor) {
 		printf("Draw: can only draw on truecolor displays!\n");
@@ -66,6 +69,7 @@ LeDraw::~LeDraw()
 		image->data = NULL;
 		XDestroyImage(image);
 	}
+	free(translated);
 }
 
 /*****************************************************************************/
@@ -76,7 +80,16 @@ LeDraw::~LeDraw()
 */
 void LeDraw::setPixels(const void * data)
 {
+	char* src = (char*) data;
+	char* dest = (char*) translated;
+
+	for (int i=0;i<width*height*4;i+=4) {
+		dest[i]   = src[i+2];
+		dest[i+1] = src[i+1];
+		dest[i+2] = src[i];
+		dest[i+3] = src[i+3];
+	}
 	XImage * image = (XImage *) bitmap;
-	image->data = (char *) data;
+	image->data = dest;
 	XPutImage((Display *) frontContext.display, (Drawable) frontContext.window, (GC) frontContext.gc, image, 0, 0, 0, 0, width, height);
 }

--- a/engine/draw_unix.cpp
+++ b/engine/draw_unix.cpp
@@ -42,15 +42,12 @@
 
 #include <stdio.h>
 
-static char* translated = 0;
-
 /*****************************************************************************/
 LeDraw::LeDraw(LeDrawingContext context, int width, int height) :
 	width(width), height(height),
 	frontContext(context),
 	bitmap(0)
 {
-	translated = (char*) malloc(width * height * 4 * sizeof(char));
 	Visual * visual = DefaultVisual((Display *) context.display, 0);
 	if (visual->c_class != TrueColor) {
 		printf("Draw: can only draw on truecolor displays!\n");
@@ -69,7 +66,6 @@ LeDraw::~LeDraw()
 		image->data = NULL;
 		XDestroyImage(image);
 	}
-	free(translated);
 }
 
 /*****************************************************************************/
@@ -80,15 +76,6 @@ LeDraw::~LeDraw()
 */
 void LeDraw::setPixels(const void * data)
 {
-	char* src = (char*) data;
-	char* dest = (char*) translated;
-
-	for (int i=0;i<width*height*4;i+=4) {
-		dest[i]   = src[i+2];
-		dest[i+1] = src[i+1];
-		dest[i+2] = src[i];
-		dest[i+3] = src[i+3];
-	}
 	XImage * image = (XImage *) bitmap;
 	image->data = (char*) data;
 	XPutImage((Display *) frontContext.display, (Drawable) frontContext.window, (GC) frontContext.gc, image, 0, 0, 0, 0, width, height);

--- a/engine/draw_unix.cpp
+++ b/engine/draw_unix.cpp
@@ -90,6 +90,6 @@ void LeDraw::setPixels(const void * data)
 		dest[i+3] = src[i+3];
 	}
 	XImage * image = (XImage *) bitmap;
-	image->data = dest;
+	image->data = (char*) data;
 	XPutImage((Display *) frontContext.display, (Drawable) frontContext.window, (GC) frontContext.gc, image, 0, 0, 0, 0, width, height);
 }

--- a/engine/draw_win.cpp
+++ b/engine/draw_win.cpp
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -71,11 +71,7 @@ void LeDraw::setPixels(const void * data)
 	info.bV4Height = -height;
 	info.bV4Planes = 1;
 	info.bV4BitCount = 32;
-	info.bV4V4Compression = BI_BITFIELDS;
-	info.bV4RedMask = 0xFF;
-	info.bV4GreenMask = 0xFF00;
-	info.bV4BlueMask = 0xFF0000;
-	info.bV4AlphaMask = 0xFF000000;
+	info.bV4V4Compression = BI_RGB;
 
 	SetDIBitsToDevice((HDC) frontContext.gc, 0, 0, width, height, 0, 0, 0, height, data, (BITMAPINFO *) &info, DIB_RGB_COLORS);
 }

--- a/engine/draw_win.cpp
+++ b/engine/draw_win.cpp
@@ -71,7 +71,11 @@ void LeDraw::setPixels(const void * data)
 	info.bV4Height = -height;
 	info.bV4Planes = 1;
 	info.bV4BitCount = 32;
-	info.bV4V4Compression = BI_RGB;
+	info.bV4V4Compression = BI_BITFIELDS;
+	info.bV4RedMask = 0xFF;
+	info.bV4GreenMask = 0xFF00;
+	info.bV4BlueMask = 0xFF0000;
+	info.bV4AlphaMask = 0xFF000000;
 
 	SetDIBitsToDevice((HDC) frontContext.gc, 0, 0, width, height, 0, 0, 0, height, data, (BITMAPINFO *) &info, DIB_RGB_COLORS);
 }

--- a/engine/global.cpp
+++ b/engine/global.cpp
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,15 @@
 #include <string.h>
 
 /*****************************************************************************/
+
+#if __APPLE__
+void * _aligned_malloc(size_t size, size_t alignment) {
+	void * buffer;
+	posix_memalign(&buffer, alignment, size);
+	return buffer;
+}
+#endif
+
 void LeGlobal::toLower(char * txt)
 {
 	int len = strlen(txt);

--- a/engine/global.h
+++ b/engine/global.h
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -79,11 +79,7 @@
 			#define _aligned_free(p) free(p)
 		#endif
 	#elif __APPLE__
-		void * _aligned_malloc(size_t size, size_t alignment) {
-			void * buffer;
-			posix_memalign(&buffer, alignment, size);
-			return buffer;
-		}
+		void * _aligned_malloc(size_t size, size_t alignment);
 		#define _aligned_free  free
 	#endif
 	

--- a/engine/light.cpp
+++ b/engine/light.cpp
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -41,12 +41,12 @@
 /*****************************************************************************/
 LeLight::LeLight() :
 	type(LE_LIGHT_AMBIENT),
-	axis(), color(0x00CCCCCC),
+	axis(), color(0xCCCCCC00),
 	rolloff(1.0f)
 {
 }
 
-LeLight::LeLight(LE_LIGHT_TYPES type, uint32_t color) :
+LeLight::LeLight(LE_LIGHT_TYPES type, LeColor color) :
 	type(type),
 	axis(), color(color),
 	rolloff(1.0f)
@@ -62,7 +62,7 @@ LeLight::LeLight(LE_LIGHT_TYPES type, uint32_t color) :
 void LeLight::black(LeMesh * mesh)
 {
 	if (!mesh->shades) mesh->allocateShades();
-	memset(mesh->shades, 0, sizeof(uint32_t) * mesh->noTriangles);
+	memset(mesh->shades, 0, sizeof(LeColor) * mesh->noTriangles);
 }
 
 /**
@@ -116,7 +116,7 @@ inline void LeLight::shineDirectional(LeMesh * mesh)
 
 	for (int j = 0; j < mesh->noTriangles; j++) {
 		float p = -rp.dot(mesh->normals[j]);
-		if (p > 0.0f) blendColors(0xFFFFFF, color, p, mesh->shades[j]);
+		if (p > 0.0f) blendColors(0xFFFFFF00, color, p, mesh->shades[j]);
 	}
 }
 
@@ -135,7 +135,7 @@ inline void LeLight::shineAmbient(LeMesh * mesh)
 	\param[in] factor blend factor (0.0 - 1.0)
 	\param[in] result accumulated color result
 */
-void LeLight::blendColors(uint32_t color1, uint32_t color2, float factor, uint32_t &result)
+void LeLight::blendColors(LeColor color1, LeColor color2, float factor, LeColor &result)
 {
 	uint8_t * c1 = (uint8_t *) &color1;
 	uint8_t * c2 = (uint8_t *) &color2;

--- a/engine/light.cpp
+++ b/engine/light.cpp
@@ -137,11 +137,8 @@ inline void LeLight::shineAmbient(LeMesh * mesh)
 */
 void LeLight::blendColors(LeColor color1, LeColor color2, float factor, LeColor &result)
 {
-	uint8_t * c1 = (uint8_t *) &color1;
-	uint8_t * c2 = (uint8_t *) &color2;
-	uint8_t * r	 = (uint8_t *) &result;
 	uint32_t f = (uint32_t) (factor * 65536.0f);
-	r[0] = cbound(r[0] + ((c1[0] * c2[0] * f) >> 24), 0, 255);
-	r[1] = cbound(r[1] + ((c1[1] * c2[1] * f) >> 24), 0, 255);
-	r[2] = cbound(r[2] + ((c1[2] * c2[2] * f) >> 24), 0, 255);
+	result.r = cbound(result.r + ((color1.r * color2.r * f) >> 24), 0, 255);
+	result.g = cbound(result.g + ((color1.g * color2.g * f) >> 24), 0, 255);
+	result.b = cbound(result.b + ((color1.b * color2.b * f) >> 24), 0, 255);
 }

--- a/engine/light.cpp
+++ b/engine/light.cpp
@@ -41,7 +41,7 @@
 /*****************************************************************************/
 LeLight::LeLight() :
 	type(LE_LIGHT_AMBIENT),
-	axis(), color(0xCCCCCC00),
+	axis(), color(LeColor::rgb(0xCCCCCC)),
 	rolloff(1.0f)
 {
 }
@@ -116,7 +116,7 @@ inline void LeLight::shineDirectional(LeMesh * mesh)
 
 	for (int j = 0; j < mesh->noTriangles; j++) {
 		float p = -rp.dot(mesh->normals[j]);
-		if (p > 0.0f) blendColors(0xFFFFFF00, color, p, mesh->shades[j]);
+		if (p > 0.0f) blendColors(LeColor::rgb(0xFFFFFF), color, p, mesh->shades[j]);
 	}
 }
 

--- a/engine/light.h
+++ b/engine/light.h
@@ -36,6 +36,7 @@
 #include "global.h"
 #include "config.h"
 
+#include "color.h"
 #include "geometry.h"
 #include "mesh.h"
 
@@ -59,14 +60,14 @@ class LeLight
 {
 public:
 	LeLight();
-	LeLight(LE_LIGHT_TYPES type, uint32_t color);
+	LeLight(LE_LIGHT_TYPES type, LeColor color);
 
 	static void black(LeMesh * mesh);
 	void shine(LeMesh * mesh);
 
 	LE_LIGHT_TYPES type;		/**< Model of the light */
 	LeAxis axis;				/**< Axis (source and direction) of the light */
-	uint32_t color;				/**< Diffuse color of the light */
+	LeColor color;				/**< Diffuse color of the light */
 	float rolloff;				/**< Roll off factor (point model) of the light */
 
 private:
@@ -75,7 +76,7 @@ private:
 	void shineAmbient(LeMesh * mesh);
 
 public:
-	static void blendColors(uint32_t color1, uint32_t color2, float factor, uint32_t &result);
+	static void blendColors(LeColor color1, LeColor color2, float factor, LeColor &result);
 
 };
 

--- a/engine/mesh.cpp
+++ b/engine/mesh.cpp
@@ -56,7 +56,7 @@ LeMesh::LeMesh() :
 LeMesh::LeMesh(LeVertex vertexes[], int noVertexes,
 			float texCoords[], int noTexCoords,
 			int vertexList[], int texCoordsList[],
-			uint32_t colors[], int noTriangles) :
+			LeColor colors[], int noTriangles) :
 	view(),
 	pos(), scale(1.0f, 1.0f, 1.0f), angle(),
 	vertexes(vertexes), noVertexes(noVertexes),
@@ -97,8 +97,8 @@ void LeMesh::allocate(int noVertexes, int noTexCoords, int noTriangles)
 	texCoordsList = new int[noTriangles * 3];
 	texSlotList = new int[noTriangles];
 
-	colors = new uint32_t[noTriangles];
-	memset(colors, 0xFF, sizeof(uint32_t) * noTriangles);
+	colors = new LeColor[noTriangles];
+	memset(colors, 0xFF, sizeof(LeColor) * noTriangles);
 	
 	this->noTriangles = noTriangles;
 	allocated = true;
@@ -164,8 +164,8 @@ void LeMesh::shadowCopy(LeMesh * copy) const
 		memcpy(copy->normals, normals, noTriangles * sizeof(LeVertex));
 	}
 	if (shades) {
-		copy->shades = new uint32_t[noTriangles];
-		memcpy(copy->shades, shades, noTriangles * sizeof(uint32_t));
+		copy->shades = new LeColor[noTriangles];
+		memcpy(copy->shades, shades, noTriangles * sizeof(LeColor));
 	}
 }
 
@@ -192,8 +192,8 @@ void LeMesh::copy(LeMesh * copy) const
 		memcpy(copy->normals, normals, noTriangles * sizeof(LeVertex));
 	}
 	if (shades) {
-		copy->shades = new uint32_t[noTriangles];
-		memcpy(copy->shades, shades, noTriangles * sizeof(uint32_t));
+		copy->shades = new LeColor[noTriangles];
+		memcpy(copy->shades, shades, noTriangles * sizeof(LeColor));
 	}
 }
 
@@ -271,7 +271,7 @@ void LeMesh::allocateNormals()
 void LeMesh::allocateShades()
 {
 	if (!shades){
-		shades = new uint32_t[noTriangles];
-		memset(shades, 0xFF, noTriangles * sizeof(uint32_t));
+		shades = new LeColor[noTriangles];
+		memset(shades, 0xFF, noTriangles * sizeof(LeColor));
 	}
 }

--- a/engine/mesh.h
+++ b/engine/mesh.h
@@ -36,6 +36,7 @@
 #include "global.h"
 #include "config.h"
 
+#include "color.h"
 #include "geometry.h"
 
 /*****************************************************************************/
@@ -49,7 +50,7 @@ public:
 	LeMesh();
 	LeMesh(LeVertex vertexes[], int noVertexes, float texCoords[], int noTexCoords,
 		 int vertexList[], int texCoordsList[],
-		 uint32_t colors[], int noTriangles);
+		 LeColor colors[], int noTriangles);
 	virtual ~LeMesh();
 
 	void shadowCopy(LeMesh * copy) const;
@@ -81,12 +82,12 @@ public:
 	int * vertexList;					/**< Triangles - vertex indexes tripplets */
 	int * texCoordsList;				/**< Triangles - texture coordinate indexes tripplets */
 	int * texSlotList;					/**< Triangles - texture slots */
-	uint32_t * colors;					/**< Triangles - colors */
+	LeColor * colors;					/**< Triangles - colors */
 	int noTriangles;					/**< Number of triangles in the mesh */
 
 // Computed mesh data
 	LeVertex * normals;					/** Normal vector per triangle */
-	uint32_t * shades;					/** Shade color per triangle (lighting) */
+	LeColor * shades;					/** Shade color per triangle (lighting) */
 
 	bool allocated;						/** Has data been allocated */
 };

--- a/engine/objfile.cpp
+++ b/engine/objfile.cpp
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -484,7 +484,6 @@ void LeObjFile::importTriangles(FILE * file, LeMesh * mesh)
 	mesh->colors = new LeColor[nb];
 	memset(mesh->colors, 0, nb * sizeof(LeColor));
 	mesh->noTriangles = nb;
-	static bool doit = true;
 // Import the triangles
 	int start = ftell(file);
 	int len = readLine(file, line, LE_OBJ_MAX_LINE);

--- a/engine/objfile.cpp
+++ b/engine/objfile.cpp
@@ -481,10 +481,10 @@ void LeObjFile::importTriangles(FILE * file, LeMesh * mesh)
 	memset(mesh->texCoordsList, 0, 3 * nb * sizeof(int));
 	mesh->texSlotList = new int[nb];
 	memset(mesh->texSlotList, 0, nb * sizeof(int));
-	mesh->colors = new uint32_t[nb];
-	memset(mesh->colors, 0, nb * sizeof(uint32_t));
+	mesh->colors = new LeColor[nb];
+	memset(mesh->colors, 0, nb * sizeof(LeColor));
 	mesh->noTriangles = nb;
-
+	static bool doit = true;
 // Import the triangles
 	int start = ftell(file);
 	int len = readLine(file, line, LE_OBJ_MAX_LINE);
@@ -492,10 +492,9 @@ void LeObjFile::importTriangles(FILE * file, LeMesh * mesh)
 	while (len) {
 		if (strncmp(line, objFace, 2) == 0) {
 			readTriangle(line, mesh, index);
-			uint32_t r = (uint32_t) cbound(curMaterial->diffuse[0] * 255.0f, 0.0f, 255.0f);
-			uint32_t g = (uint32_t) cbound(curMaterial->diffuse[1] * 255.0f, 0.0f, 255.0f);
-			uint32_t b = (uint32_t) cbound(curMaterial->diffuse[2] * 255.0f, 0.0f, 255.0f);
-			mesh->colors[index] = r | (g << 8) | (b << 16);
+			mesh->colors[index].r = cbound(curMaterial->diffuse[0] * 255.0f, 0.0f, 255.0f);
+			mesh->colors[index].g = cbound(curMaterial->diffuse[1] * 255.0f, 0.0f, 255.0f);
+			mesh->colors[index].b = cbound(curMaterial->diffuse[2] * 255.0f, 0.0f, 255.0f);
 
 			int slot = 0;
 			const char * texName = curMaterial->texture;

--- a/engine/rasterizer_float.cpp
+++ b/engine/rasterizer_float.cpp
@@ -61,7 +61,7 @@ LeRasterizer::LeRasterizer(int width, int height) :
 	memset(vs, 0, sizeof(float) * 4);
 
 	frame.allocate(width, height + 2);
-	frame.clear(0);
+	frame.clear(background);
 	pixels = ((LeColor *) frame.data) + frame.tx;
 }
 

--- a/engine/rasterizer_float.cpp
+++ b/engine/rasterizer_float.cpp
@@ -11,7 +11,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,7 @@ LeRasterizer::LeRasterizer(int width, int height) :
 
 	frame.allocate(width, height + 2);
 	frame.clear(0);
-	pixels = ((uint32_t *) frame.data) + frame.tx;
+	pixels = ((LeColor *) frame.data) + frame.tx;
 }
 
 LeRasterizer::~LeRasterizer()
@@ -152,7 +152,7 @@ void LeRasterizer::rasterList(LeTriList * trilist)
 	#endif
 
 	// Retrieve texture information
-		texPixels = (uint32_t *) bmp->data;
+		texPixels = (LeColor *) bmp->data;
 		texSizeU = bmp->txP2;
 		texSizeV = bmp->tyP2;
 		texMaskU = (1 << bmp->txP2) - 1;
@@ -314,7 +314,7 @@ inline void LeRasterizer::fillFlatTexZC(int y, float x1, float x2, float w1, flo
 
 	int xb = (int) floorf(x1);
 	int xe = (int) ceilf(x2);
-	uint32_t * p = xb + ((int) y) * frame.tx + pixels;
+	LeColor * p = xb + ((int) y) * frame.tx + pixels;
 	int b = (xe - xb) >> 2;
 	int r = (xe - xb) & 0x3;
 
@@ -419,7 +419,7 @@ inline void LeRasterizer::fillFlatTexAlphaZC(int y, float x1, float x2, float w1
 
 	int xb = (int) floorf(x1);
 	int xe = (int) ceilf(x2);
-	uint32_t * p = xb + ((int) y) * frame.tx + pixels;
+	LeColor * p = xb + ((int) y) * frame.tx + pixels;
 	int b = (xe - xb) >> 2;
 	int r = (xe - xb) & 0x3;
 

--- a/engine/rasterizer_float.h
+++ b/engine/rasterizer_float.h
@@ -11,7 +11,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,7 @@ public:
 	void flush();
 
 	LeBitmap frame;				/**< Frame buffer */ 
-	uint32_t background;		/**< Background color */ 
+	LeColor background;		/**< Background color */ 
 	
 private:
 	void topTriangleZC(int vt, int vm1, int vm2);
@@ -71,11 +71,11 @@ private:
 	inline void fillFlatTexZC(int y, float x1, float x2, float w1, float w2, float u1, float u2, float v1, float v2);
 	inline void fillFlatTexAlphaZC(int y, float x1, float x2, float w1, float w2, float u1, float u2, float v1, float v2);
 
-	uint32_t color;
+	LeColor color;
 	LeBitmap * bmp;
 
-	uint32_t * pixels;
-	uint32_t * texPixels;
+	LeColor * pixels;
+	LeColor * texPixels;
 	uint32_t texSizeU;
 	uint32_t texSizeV;
 	uint32_t texMaskU;

--- a/engine/rasterizer_integer.cpp
+++ b/engine/rasterizer_integer.cpp
@@ -47,8 +47,8 @@
 /*****************************************************************************/
 LeRasterizer::LeRasterizer(int width, int height) :
 	frame(),
-	background(0),
-	color(0xFFFFFF00),
+	background(LeColor()),
+	color(LeColor::rgb(0xFFFFFF)),
 	bmp(NULL),
 	texPixels(NULL),
 	texSizeU(0), texSizeV(0),
@@ -61,7 +61,7 @@ LeRasterizer::LeRasterizer(int width, int height) :
 	memset(vs, 0, sizeof(int32_t) * 4);
 
 	frame.allocate(width, height + 2);
-	frame.clear(0);
+	frame.clear(LeColor());
 
 	pixels = ((LeColor *) frame.data) + frame.tx;
 }

--- a/engine/rasterizer_integer.h
+++ b/engine/rasterizer_integer.h
@@ -11,7 +11,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2017-2018 Frédéric Meslin
+	Copyright (c) 2017-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,7 @@ public:
 	void flush();
 
 	LeBitmap frame;				/**< Frame buffer */ 
-	uint32_t background;		/**< Background color */ 
+	LeColor background;		/**< Background color */ 
 	
 private:
 	void topTriangleZC(int vt, int vm1, int vm2);
@@ -71,11 +71,11 @@ private:
 	inline void fillFlatTexZC(int y, int x1, int x2, int w1, int w2, int u1, int u2, int v1, int v2);
 	inline void fillFlatTexAlphaZC(int y, int x1, int x2, int w1, int w2, int u1, int u2, int v1, int v2);
 
-	uint32_t color;
+	LeColor color;
 	LeBitmap * bmp;
 
-	uint32_t * pixels;
-	uint32_t * texPixels;
+	LeColor * pixels;
+	LeColor * texPixels;
 	uint32_t texSizeU;
 	uint32_t texSizeV;
 	uint32_t texMaskU;

--- a/engine/renderer.h
+++ b/engine/renderer.h
@@ -43,6 +43,7 @@
 #include "global.h"
 #include "config.h"
 
+#include "color.h"
 #include "geometry.h"
 #include "mesh.h"
 #include "bset.h"
@@ -103,7 +104,7 @@ private:
 	int extra;							/**< Index of extra triangles */
 	int extraMax;						/**< Maximum number of extra triangles */
 
-	uint32_t * colors;					/**< Color table for triangles */
+	LeColor * colors;					/**< Color table for triangles */
 
 	LeVertex viewPosition;				/**< View position of renderer */
 	LeVertex viewAngle;					/**< View angle of renderer (in degrees) */

--- a/engine/trilist.h
+++ b/engine/trilist.h
@@ -36,6 +36,8 @@
 #include "global.h"
 #include "config.h"
 
+#include "color.h"
+
 /*****************************************************************************/
 /**
 	\class LeTriangle
@@ -49,7 +51,7 @@ struct LeTriangle
 	float us[4];		/**< u texture coordinate of vertexes */
 	float vs[4];		/**< v texture coordinate of vertexes */
 	float vd;			/**< average view distance */
-	uint32_t color;		/**< solid color */
+	LeColor color;		/**< solid color */
 	int tex;			/**< texture slot */
 };
 

--- a/engine/window_win.cpp
+++ b/engine/window_win.cpp
@@ -9,7 +9,7 @@
 	\version 1.6
 
 	The MIT License (MIT)
-	Copyright (c) 2015-2018 Frédéric Meslin
+	Copyright (c) 2015-2018 FrÃ©dÃ©ric Meslin
 
 	Permission is hereby granted, free of charge, to any person obtaining a copy
 	of this software and associated documentation files (the "Software"), to deal

--- a/examples/cube/cube_unix.cpp
+++ b/examples/cube/cube_unix.cpp
@@ -42,9 +42,9 @@ int main()
 	LeMesh * crate = meshCache.cacheSlots[crateSlot].mesh;
 
 /** Create three lights */
-	LeLight light1(LE_LIGHT_DIRECTIONAL, 0xFF4040);
-	LeLight light2(LE_LIGHT_DIRECTIONAL, 0x4040FF);
-	LeLight light3(LE_LIGHT_AMBIENT, 0x404040);
+	LeLight light1(LE_LIGHT_DIRECTIONAL, 0xFF404000);
+	LeLight light2(LE_LIGHT_DIRECTIONAL, 0x4040FF00);
+	LeLight light3(LE_LIGHT_AMBIENT, 0x40404000);
 
 	light1.axis = LeAxis(LeVertex(), LeVertex(1.0f, 0.0f, -1.0f));
 	light2.axis = LeAxis(LeVertex(), LeVertex(-1.0f, 0.0f, -1.0f));
@@ -52,7 +52,7 @@ int main()
 /** Set the renderer properties */
 	renderer.setViewPosition(LeVertex(0.0f, 0.0f, 3.0f));
 	renderer.updateViewMatrix();
-	rasterizer.background = 0xC0C0FF;
+	rasterizer.background = 0xC0C0FF00;
 
 /** Initialize the timing */
 	timing.setup(60);

--- a/examples/cube/cube_unix.cpp
+++ b/examples/cube/cube_unix.cpp
@@ -42,9 +42,9 @@ int main()
 	LeMesh * crate = meshCache.cacheSlots[crateSlot].mesh;
 
 /** Create three lights */
-	LeLight light1(LE_LIGHT_DIRECTIONAL, 0xFF404000);
-	LeLight light2(LE_LIGHT_DIRECTIONAL, 0x4040FF00);
-	LeLight light3(LE_LIGHT_AMBIENT, 0x40404000);
+	LeLight light1(LE_LIGHT_DIRECTIONAL, LeColor::rgb(0xFF4040));
+	LeLight light2(LE_LIGHT_DIRECTIONAL, LeColor::rgb(0x4040FF));
+	LeLight light3(LE_LIGHT_AMBIENT, LeColor::rgb(0x404040));
 
 	light1.axis = LeAxis(LeVertex(), LeVertex(1.0f, 0.0f, -1.0f));
 	light2.axis = LeAxis(LeVertex(), LeVertex(-1.0f, 0.0f, -1.0f));
@@ -52,7 +52,7 @@ int main()
 /** Set the renderer properties */
 	renderer.setViewPosition(LeVertex(0.0f, 0.0f, 3.0f));
 	renderer.updateViewMatrix();
-	rasterizer.background = 0xC0C0FF00;
+	rasterizer.background = LeColor::rgb(0xC0C0FF);
 
 /** Initialize the timing */
 	timing.setup(60);

--- a/examples/cube/cube_win.cpp
+++ b/examples/cube/cube_win.cpp
@@ -34,9 +34,9 @@ int main()
 	LeMesh * crate = meshCache.cacheSlots[crateSlot].mesh;
 
 /** Create three lights */
-	LeLight light1(LE_LIGHT_DIRECTIONAL, 0xFF404000);
-	LeLight light2(LE_LIGHT_DIRECTIONAL, 0x4040FF00);
-	LeLight light3(LE_LIGHT_AMBIENT, 0x40404000);
+	LeLight light1(LE_LIGHT_DIRECTIONAL, LeColor::rgb(0xFF4040));
+	LeLight light2(LE_LIGHT_DIRECTIONAL, LeColor::rgb(0x4040FF));
+	LeLight light3(LE_LIGHT_AMBIENT, LeColor::rgb(0x404040));
 
 	light1.axis = LeAxis(LeVertex(), LeVertex(1.0f, 0.0f, -1.0f));
 	light2.axis = LeAxis(LeVertex(), LeVertex(-1.0f, 0.0f, -1.0f));
@@ -44,7 +44,7 @@ int main()
 /** Set the renderer properties */
 	renderer.setViewPosition(LeVertex(0.0f, 0.0f, 3.0f));
 	renderer.updateViewMatrix();
-	rasterizer.background = 0xC0C0FF00;
+	rasterizer.background = LeColor::rgb(0xC0C0FF);
 
 /** Initialize the timing */
 	timing.setup(60);

--- a/examples/cube/cube_win.cpp
+++ b/examples/cube/cube_win.cpp
@@ -34,9 +34,9 @@ int main()
 	LeMesh * crate = meshCache.cacheSlots[crateSlot].mesh;
 
 /** Create three lights */
-	LeLight light1(LE_LIGHT_DIRECTIONAL, 0xFF4040);
-	LeLight light2(LE_LIGHT_DIRECTIONAL, 0x4040FF);
-	LeLight light3(LE_LIGHT_AMBIENT, 0x404040);
+	LeLight light1(LE_LIGHT_DIRECTIONAL, 0xFF404000);
+	LeLight light2(LE_LIGHT_DIRECTIONAL, 0x4040FF00);
+	LeLight light3(LE_LIGHT_AMBIENT, 0x40404000);
 
 	light1.axis = LeAxis(LeVertex(), LeVertex(1.0f, 0.0f, -1.0f));
 	light2.axis = LeAxis(LeVertex(), LeVertex(-1.0f, 0.0f, -1.0f));
@@ -44,7 +44,7 @@ int main()
 /** Set the renderer properties */
 	renderer.setViewPosition(LeVertex(0.0f, 0.0f, 3.0f));
 	renderer.updateViewMatrix();
-	rasterizer.background = 0xC0C0FF;
+	rasterizer.background = 0xC0C0FF00;
 
 /** Initialize the timing */
 	timing.setup(60);


### PR DESCRIPTION
WIP - do not merge yet (unless you know immediately how to fix it or you )

enabling SSE2 results in cyan 👎 

rest seems ok

with this change I see the same triangle problems that I have on the Amiga (let the cube rotate for a while - suddenly colors are off).

Will check if I can find out why it is broken and add to this pull request.

Todos:

- [x] Test UNIX
- [x] Test GCC
- [x] Fix triangle glitches
- [x] Fix SSE2