### PR TITLE
bmptype doesn't need any conversion

### DIFF
--- a/engine/bmpfile.cpp
+++ b/engine/bmpfile.cpp
@@ -159,7 +159,6 @@ int LeBmpFile::readBitmap(FILE * file, LeBitmap * bitmap)
 	fread(&infoHeader, sizeof(BMPINFOHEADER), 1, file);
 	
 // Format the data (little-endianness)
-	FROM_LEU16(fileHeader.bfType);
 	FROM_LEU32(fileHeader.bfSize);
 	FROM_LEU32(fileHeader.bfOffBits);
 	FROM_LEU32(infoHeader.biSize);


### PR DESCRIPTION
it is wordsized but interpreted byte by byte...otherwise the amiga will see "MB" and fail to recongnize the file as bmp...

rest is working 🎉 