### PR TITLE
fix include path when embedding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,31 @@
 project(le3d C CXX)
 cmake_minimum_required(VERSION 3.4)
 set(CMAKE_CXX_STANDARD 98)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
 option(LE3D_BUILD_EXAMPLES "Build the example programs" ON)
 
 SET(le3d_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
+
+include(le3d-options)
+# transform all options to int values so it can be used within configure_file
+# cmake provides #cmakedefine01 but we are prefixing the config variables in its
+# full form "LE3D" vs "LE" here so that is not useful.
+# the simple form "LE" is sufficient for the cpp code but in cmake it might be
+# ambiguous
+include(bool2int)
+bool2int(LE3D_RENDERER_3DFRUSTRUM)
+bool2int(LE3D_RENDERER_2DFRAME)
+bool2int(LE3D_RENDERER_INTRASTER)
+bool2int(LE3D_RENDERER_MIPMAPS)
+bool2int(LE3D_USE_SIMD)
+bool2int(LE3D_USE_SSE2)
+
+configure_file(engine/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
+list(APPEND le3d_INCLUDE_DIRS
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 set(ENGINE_FILES
     engine/bitmap.cpp
@@ -78,18 +98,18 @@ add_library(le3d
     ${ENGINE_FILES}
 )
 
-target_include_directories(
-    le3d
-    PUBLIC
-    ${le3d_INCLUDE_DIRS}
-)
-
 target_link_libraries(
     le3d
     PUBLIC
     ${LINK_LIBRARIES}
 )
 
+
+target_include_directories(
+    le3d
+    PUBLIC
+    ${le3d_INCLUDE_DIRS}
+)
 
 set(LE3D_CXX_FLAGS_SUGGESTION "")
 if (NOT(AMIGA))
@@ -112,23 +132,6 @@ if (NOT(AMIGA))
 endif()
 
 set(LE3D_CXX_FLAGS "${LE3D_CXX_FLAGS_SUGGESTION}" CACHE STRING "le3d compile flags")
-
-include(le3d-options)
-# transform all options to int values so it can be used within configure_file
-# cmake provides #cmakedefine01 but we are prefixing the config variables in its
-# full form "LE3D" vs "LE" here so that is not useful.
-# the simple form "LE" is sufficient for the cpp code but in cmake it might be
-# ambiguous
-include(bool2int)
-bool2int(LE3D_RENDERER_3DFRUSTRUM)
-bool2int(LE3D_RENDERER_2DFRAME)
-bool2int(LE3D_RENDERER_INTRASTER)
-bool2int(LE3D_RENDERER_MIPMAPS)
-bool2int(LE3D_USE_SIMD)
-bool2int(LE3D_USE_SSE2)
-
-configure_file(engine/config.h.in ${PROJECT_BINARY_DIR}/config.h)
-include_directories(${PROJECT_BINARY_DIR})
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LE3D_CXX_FLAGS}")
 


### PR DESCRIPTION
When embedding le3d (like pointed out in building.md) the settings were
wrong regarding include path.

CMAKE_SOURCE_DIR is referring to the main project etc.

By using target_include_path in combination with PUBLIC the main project
will inherit the include path and can include stuff from le3d