### PR TITLE
Proper CI for le3d

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+image: Visual Studio 2017
+
+environment:
+  matrix:
+    - GENERATOR: "Visual Studio 15 2017" # x86 build
+    - GENERATOR: "Visual Studio 15 2017 Win64" # x64 build
+
+platform:
+  - x64
+
+build_script:
+  - mkdir build
+  - cd build
+  - ps: cmake -G "$env:GENERATOR" ..
+  - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+sudo: required
+
+services:
+  - docker
+
+language: cpp
+matrix:
+  include:
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    - os: osx
+      osx_image: xcode8
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    # works on Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+    # clang is default on osx
+    - os: osx
+      osx_image: xcode8
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+    # AMIGAAAAAA
+    - os: linux
+      before_script:
+        - docker build -t le3d-build -f support/Dockerfile.amiga support
+      script:
+        - docker run -v $(pwd):/le3d le3d-build /le3d/support/build-amiga.sh
+
+before_script:
+    - eval "${MATRIX_EVAL}"
+
+script: support/build.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 **LightEngine 3D**  
 **Version 1.6 - 09/05/2018**
 
+[![Build Status](https://travis-ci.org/Marzac/le3d.svg?branch=master)](https://travis-ci.org/Marzac/le3d)
+
 A straightforward C++ 3D software engine for real-time graphics.  
 The engine aims to be a minimal and clear implementation of a simplified fixed pipeline.  
 Code has been designed for resource constrained platforms.  

--- a/support/Dockerfile.amiga
+++ b/support/Dockerfile.amiga
@@ -1,0 +1,3 @@
+FROM sebastianbergmann/amiga-gcc:latest
+
+RUN apt-get update && apt-get install -y cmake

--- a/support/build-amiga.sh
+++ b/support/build-amiga.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+cd /le3d
+mkdir -p build-amiga
+cd build-amiga
+cmake -DCMAKE_BUILD_TYPE=Release -DLE3D_RENDERER_INTRASTER=On -DAMIGA_TOOLCHAIN_PATH=/opt/amiga/ -DCMAKE_TOOLCHAIN_FILE=../amiga.cmake ..
+make

--- a/support/build.sh
+++ b/support/build.sh
@@ -1,0 +1,4 @@
+mkdir build
+cd build
+cmake ..
+make


### PR DESCRIPTION
This adds CI support for Windows/Mac/Linux/Amiga

I have already added a badge for travis. Appveyor badge had something dynamic in its url.

Interestingly also the windows version is failing right now :S

https://ci.appveyor.com/project/m0ppers/le3d

not really sure why this is. Also this doesn't happen for me locally. That being said: that is the whole point of the CI stuff. Namely to remove "works for me" :D