### PR TITLE
Add copysignf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ elseif (UNIX AND APPLE)
     )
 elseif (AMIGA)
     list(APPEND ENGINE_FILES
+        engine/amiga/missing-math-impl.cpp
         engine/system_amiga.cpp
         engine/draw_amiga.cpp
         engine/window_amiga.cpp

--- a/engine/amiga/missing-math-impl.cpp
+++ b/engine/amiga/missing-math-impl.cpp
@@ -1,0 +1,65 @@
+/*
+BSD 3-Clause License
+
+Copyright (c) 2016, Olaf Barthel
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// from clib2
+
+#include <math.h>
+
+typedef union
+{
+  float value;
+  unsigned int word;
+} ieee_float_shape_type;
+
+#define GET_FLOAT_WORD(i,d)		\
+do {							\
+  ieee_float_shape_type gf_u;	\
+  gf_u.value = (d);				\
+  (i) = gf_u.word;				\
+} while (0)
+
+#define SET_FLOAT_WORD(d,i)		\
+do {							\
+  ieee_float_shape_type sf_u;	\
+  sf_u.word = (i);				\
+  (d) = sf_u.value;				\
+} while (0)
+
+float
+copysignf(float x, float y)
+{
+	unsigned long ix,iy;
+	GET_FLOAT_WORD(ix,x);
+	GET_FLOAT_WORD(iy,y);
+	SET_FLOAT_WORD(x,(ix&0x7fffffff)|(iy&0x80000000U));
+	return x;
+}

--- a/engine/global.h
+++ b/engine/global.h
@@ -140,11 +140,6 @@
 	#define M_PI		3.14159265358979323846
 #endif
 
-#if defined (AMIGA)
-// These are missing
-	#define copysignf(x, y)	((float) copysign(x, y))
-#endif
-
 /*****************************************************************************/
 /** Endianness conversion macros */
 #define FROM_LEU16(x) (x = ((uint8_t *) &(x))[0] + (((uint8_t *) &(x))[1] << 8))


### PR DESCRIPTION
Couldn't find a different solution unfortunately. The toolchain contains multiple options and c libraries. When switching to the alternative I got even harder linker errors. So the only fallback I see right now is to just implement the missing functions :S

Stolen from here:

https://github.com/adtools/clib2